### PR TITLE
Change type for the Sequence field to int64

### DIFF
--- a/product.go
+++ b/product.go
@@ -62,7 +62,7 @@ type BookEntry struct {
 }
 
 type Book struct {
-	Sequence int         `json:"sequence"`
+	Sequence int64       `json:"sequence"`
 	Bids     []BookEntry `json:"bids"`
 	Asks     []BookEntry `json:"asks"`
 }


### PR DESCRIPTION
On 32-bit operating systems the Book.Sequence field is too small to hold currently-used sequence numbers:

`GetBook(): json: cannot unmarshal number 5143764863 into Go struct field Book.sequence of type int`