### PR TITLE
updates readme to ensure secrets are base64 encoded

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,14 +277,17 @@ Get Trade history:
 ```
 
 ### Testing
+
 To test with Coinbase's public sandbox set the following environment variables:
+
 ```sh
-export COINBASE_PRO_KEY="sandbox key"
-export COINBASE_PRO_PASSPHRASE="sandbox passphrase"
-export COINBASE_PRO_SECRET="sandbox secret"
+export COINBASE_PRO_KEY=$(eval echo "sandbox key" | base64)
+export COINBASE_PRO_PASSPHRASE=$(eval echo "sandbox passphrase" | base64)
+export COINBASE_PRO_SECRET=$(eval echo "sandbox secret" | base64)
 ```
 
 Then run `go test`
+
 ```sh
 go test
 ```


### PR DESCRIPTION
When running the tests using the provided instructions there are several failures produced due to the fact that the secrets are not `base64` encoded. This patch updates the documentation to indicate that they should be base64 encoded in order for this library to work correctly.

```console
--- FAIL: TestCancelOrder (0.00s)
    order_test.go:77: illegal base64 data at input byte 7
    order_test.go:81: illegal base64 data at input byte 7
    order_test.go:82: illegal base64 data at input byte 7
--- FAIL: TestGetOrder (0.00s)
    order_test.go:98: illegal base64 data at input byte 7
    order_test.go:103: illegal base64 data at input byte 7
    order_test.go:111: illegal base64 data at input byte 7
--- FAIL: TestListOrders (0.00s)
    order_test.go:122: illegal base64 data at input byte 7
    order_test.go:135: illegal base64 data at input byte 7
--- FAIL: TestCancelAllOrders (0.00s)
    order_test.go:154: illegal base64 data at input byte 7
    order_test.go:154: illegal base64 data at input byte 7
    order_test.go:160: illegal base64 data at input byte 7
    order_test.go:164: Did not cancel all orders
```