### PR TITLE
Extend Product struct with undocumented fields

### DIFF
--- a/product.go
+++ b/product.go
@@ -16,6 +16,16 @@ type Product struct {
 	BaseMinSize    string `json:"base_min_size"`
 	BaseMaxSize    string `json:"base_max_size"`
 	QuoteIncrement string `json:"quote_increment"`
+	BaseIncrement  string `json:"base_increment"`
+	DisplayName    string `json:"display_name"`
+	MinMarketFunds string `json:"min_market_funds"`
+	MaxMarketFunds string `json:"max_market_funds"`
+	MarginEnabled  bool   `json:"margin_enabled"`
+	PostOnly       bool   `json:"post_only"`
+	LimitOnly      bool   `json:"limit_only"`
+	CancelOnly     bool   `json:"cancel_only"`
+	Status         string `json:"status"`
+	StatusMessage  string `json:"status_message"`
 }
 
 type Ticker struct {


### PR DESCRIPTION
Products endpoint `
https://api-public.sandbox.pro.coinbase.com/products` returns more information that you can find in the documentation:
```json
{
  "id": "BAT-USDC",
  "base_currency": "BAT",
  "quote_currency": "USDC",
  "base_min_size": "1.00000000",
  "base_max_size": "300000.00000000",
  "quote_increment": "0.00000100",
  "base_increment": "1.00000000",
  "display_name": "BAT/USDC",
  "min_market_funds": "1",
  "max_market_funds": "100000",
  "margin_enabled": false,
  "post_only": false,
  "limit_only": false,
  "cancel_only": false,
  "status": "online",
  "status_message": ""
}
```

In this PR I added missing fields to the `Product` struct.