### PR TITLE
Fix GetProducts test

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,3 +288,5 @@ Then run `go test`
 ```sh
 go test
 ```
+
+Note that your sandbox account will need at least 2,000 USD and 2 BTC to run the tests.

--- a/product_test.go
+++ b/product_test.go
@@ -13,7 +13,7 @@ func TestGetProducts(t *testing.T) {
 	}
 
 	for _, p := range products {
-		if StructHasZeroValues(p) {
+		if StructHasZeroValues(p) && p.StatusMessage != "" {
 			t.Error(errors.New("Zero value"))
 		}
 	}


### PR DESCRIPTION
Per the Coinbase Pro documentation: 
> status_message provides any extra information regarding the status **if available**.

Most of the time this field will be an empty string, so the test now excludes that field from the zero values check.

I've also added a note to the testing section of the README regarding required funds for running the tests.